### PR TITLE
Add option to export only dev-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ poetry export -f requirements.txt --output requirements.txt
 * `--format (-f)`: The format to export to (default: `requirements.txt`). Currently, only `requirements.txt` is supported.
 * `--output (-o)`: The name of the output file.  If omitted, print to standard output.
 * `--dev`: Include development dependencies.
+* `--only-dev`: Include only development dependencies.
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.

--- a/src/poetry_export_plugin/console/commands/export.py
+++ b/src/poetry_export_plugin/console/commands/export.py
@@ -20,6 +20,7 @@ class ExportCommand(Command):
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
         option("dev", None, "Include development dependencies."),
+        option("only-dev", None, "Include only development dependencies."),
         option(
             "extras",
             "E",
@@ -68,6 +69,7 @@ class ExportCommand(Command):
             output or self.io,
             with_hashes=not self.option("without-hashes"),
             dev=self.option("dev"),
+            only_dev=self.option("only-dev"),
             extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
         )

--- a/src/poetry_export_plugin/exporter.py
+++ b/src/poetry_export_plugin/exporter.py
@@ -32,6 +32,7 @@ class Exporter:
         output: Union["IO", str],
         with_hashes: bool = True,
         dev: bool = False,
+        only_dev: bool = False,
         extras: Optional[Union[bool, Sequence[str]]] = None,
         with_credentials: bool = False,
     ) -> None:
@@ -43,6 +44,7 @@ class Exporter:
             output,
             with_hashes=with_hashes,
             dev=dev,
+            only_dev=only_dev,
             extras=extras,
             with_credentials=with_credentials,
         )
@@ -53,6 +55,7 @@ class Exporter:
         output: Union["IO", str],
         with_hashes: bool = True,
         dev: bool = False,
+        only_dev: bool = False,
         extras: Optional[Union[bool, Sequence[str]]] = None,
         with_credentials: bool = False,
     ) -> None:
@@ -63,7 +66,7 @@ class Exporter:
         dependency_lines = set()
 
         for dependency_package in self._poetry.locker.get_project_dependency_packages(
-            project_requires=self._poetry.package.all_requires, dev=dev, extras=extras
+            project_requires=self._poetry.package.all_requires, dev=dev, only_dev=only_dev, extras=extras
         ):
             line = ""
 


### PR DESCRIPTION
This PR adds the support, for exporting only the dev-dependencies, to the export plugin.

Related to https://github.com/python-poetry/poetry/issues/1441

Opening a PR here too, as the `export` function will be soon moved as a plugin.

Extension to https://github.com/python-poetry/poetry/pull/4283

---

- [x] Updated **documentation** for changed code.